### PR TITLE
Moodle role IDs are no longer hard coded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 - Bug fix: Using {ifenrolled} and {ifnotenrolled} no longer cause a PHP error when used in a course. (thanks @gemguardian !)
 - Updated documentation and FAQ.
 - Reorganized README.md (New: logo, status badges, table of contents, contributing, etc).
-- Default Moodle role IDs are no longer hard coded but must exist including: 'manager', 'coursecreator', 'editingteacher', 'teacher', 'student'.
+- Default Moodle role IDs are no longer hard coded. {ifrolename} and {ifminrolename} type tags now use archetypes instead of role shortnames. (thanks @FMCorz !)
 - Fixed bug where no country was selected in user's profile.
 - Project status is now BETA.
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Moodle metadata filters
 
 Conditionally display content filters
 
+Note: {if`rolename`} and {ifmin`rolename`} type tags are based on role archetypes, not role shortnames. For example, you could have a role called `students` but, if the archetype for the role is `teacher`, the role will be identified as a `teacher`. Roles not based on archetypes will not with these tags.
+
 * {ifenrolled}{/ifenrolled} : Will display the enclosed content only if the user **is** enrolled in the current course.
 * {ifnotenrolled}{/ifnotenrolled} : Will display the enclosed content only if the user is **not** enrolled in the current course.
 * {ifloggedin}{/ifloggedin} : Will display the enclosed content only if the user is logged in as non-guest.


### PR DESCRIPTION
Also, {if`rolename`} and {ifmin`rolename`} type tags now use role archetypes instead of role shortnames.