### PR TITLE
Fixed https issue with ReCAPTCHA.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.4.1] - 2017-11-13
+### Updated
+- Fixed https issue with ReCAPTCHA.
+
 ## [0.4.0] - 2017-11-11
 ### Added
 Over a dozen new FilterCodes added including:

--- a/filter.php
+++ b/filter.php
@@ -171,7 +171,7 @@ class filter_filtercodes extends moodle_text_filter {
             if (!empty($CFG->recaptchaprivatekey) && !empty($CFG->recaptchapublickey)) {
                 // Yes? Generate ReCAPTCHA.
                 require_once($CFG->libdir . '/recaptchalib.php');
-                return recaptcha_get_html($CFG->recaptchapublickey);
+                return recaptcha_get_html($CFG->recaptchapublickey, null, is_https());
             } else if ($CFG->debugdisplay == 1) { // If debugging is set to DEVELOPER...
                 // Show indicator that {recaptcha} tag is not required.
                 return 'Warning: The recaptcha tag is not required here.';


### PR DESCRIPTION
The ReCAPTCHA will now be generated using the same protocol that the form was generated from.

See #44 