### PR TITLE
Added contextual styling for alert boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.0.2] 2020-10-03
+### Updated
+- Updated {alert} to allow for contextual class stying, Eg, `{alert primary}` or `{alert success}`. You can view a list of the contextual clases [here](https://getbootstrap.com/docs/4.0/components/alerts/)
+
 ## [2.0.1] 2020-10-02
 ### Added
 - New {alert}{/alert} tags (ALPHA).

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Moodle metadata filters
 * {note}content{/note} : Enables you to include a note which will not be displayed.
 * {help}content{/help} : Enables you to create popup help icons just like Moodle does.
 * {info}content{/info} : Enables you to create popup help icons just like the popup Help icons but with an "i" information icon.
-* {alert}content{/alert}: (ALPHA) Creates an alert box containing the specified content.
+* {alert ...}content{/alert}: (ALPHA) Creates an alert box containing the specified content. You can add contextual classes by adding them as a parameter. Eg, `{alert primary}` or `{alert success}`. You can view a list of the contextual clases [here](https://getbootstrap.com/docs/4.0/components/alerts/)
 * {highlight}{/highlight} : Highlight text. NOTE: Must only be used within a paragraph.
 * {profile_field_shortname} : Display's custom profile field. Replace "shortname" with the shortname of a custom profile field all in lowercase. NOTE: Will not display if custom profile field's settings are set to **Not Visible**.
 * {profilefullname}: Similar to {fullname} except that it displays a profile owner's name when placed on the Profile page.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Moodle metadata filters
 * {note}content{/note} : Enables you to include a note which will not be displayed.
 * {help}content{/help} : Enables you to create popup help icons just like Moodle does.
 * {info}content{/info} : Enables you to create popup help icons just like the popup Help icons but with an "i" information icon.
-* {alert}content{/info}: (ALPHA) Creates an alert box containing the specified content.
+* {alert}content{/alert}: (ALPHA) Creates an alert box containing the specified content.
 * {highlight}{/highlight} : Highlight text. NOTE: Must only be used within a paragraph.
 * {profile_field_shortname} : Display's custom profile field. Replace "shortname" with the shortname of a custom profile field all in lowercase. NOTE: Will not display if custom profile field's settings are set to **Not Visible**.
 * {profilefullname}: Similar to {fullname} except that it displays a profile owner's name when placed on the Profile page.

--- a/filter.php
+++ b/filter.php
@@ -1796,22 +1796,13 @@ class filter_filtercodes extends moodle_text_filter {
 
         // Tag: {alert}{/alert}.
         if (stripos($text, '{/alert}') !== false) {
-            //If {alert <style> is defined
-            // Replaces style with passed parameter 
-            if (stripos($text, '{alert ') !== false) {
-                $newtext = preg_replace_callback('/\{alert\s(.*?)\}(.*?)\{\/alert\}/is',
-                function($matches) {
-                    return '<div class="alert alert-' . $matches[1] . '" role="alert"><p>' . $matches[2] . '</p></div>';
-                }, $text);
-            }
-            if (!$newtext){
+            $newtext = preg_replace_callback('/\{alert(\s\w*)?\}(.*?)\{\/alert\}/is',
+            function($matches) {
                 // If alert <style> parameter is not included, default to alert-warning
-                $newtext = preg_replace_callback('/\{alert}(.*?)\{\/alert\}/is',
-                    function($matches) {
-                        return '<div class="alert alert-warning" role="alert"><p>' . $matches[1] . '</p></div>';
-                    }, $text);
-            }
-
+                $matches[1] = trim($matches[1]);
+                $matches[1] = empty($matches[1])? 'warning' : $matches[1];
+                return '<div class="alert alert-' . $matches[1] . '" role="alert"><p>' . $matches[2] . '</p></div>';
+            }, $text);
             if ($newtext !== false) {
                 $text = $newtext;
                 $changed = true;

--- a/filter.php
+++ b/filter.php
@@ -1796,10 +1796,19 @@ class filter_filtercodes extends moodle_text_filter {
 
         // Tag: {alert}{/alert}.
         if (stripos($text, '{/alert}') !== false) {
+            // If alert <style> parameter is not included, default to alert-warning
             $newtext = preg_replace_callback('/\{alert}(.*?)\{\/alert\}/is',
                 function($matches) {
                     return '<div class="alert alert-warning" role="alert"><p>' . $matches[1] . '</p></div>';
                 }, $text);
+            //If {alert <style> is defined
+            // Replaces style with passed parameter 
+            if (!$newtext){
+                $newtext = preg_replace_callback('/\{alert\s(.*?)\}(.*?)\{\/alert\}/is',
+                function($matches) {
+                    return '<div class="alert alert-' . $matches[1] . '" role="alert"><p>' . $matches[2] . '</p></div>';
+                }, $text);
+            }
             if ($newtext !== false) {
                 $text = $newtext;
                 $changed = true;

--- a/filter.php
+++ b/filter.php
@@ -1796,19 +1796,22 @@ class filter_filtercodes extends moodle_text_filter {
 
         // Tag: {alert}{/alert}.
         if (stripos($text, '{/alert}') !== false) {
-            // If alert <style> parameter is not included, default to alert-warning
-            $newtext = preg_replace_callback('/\{alert}(.*?)\{\/alert\}/is',
-                function($matches) {
-                    return '<div class="alert alert-warning" role="alert"><p>' . $matches[1] . '</p></div>';
-                }, $text);
             //If {alert <style> is defined
             // Replaces style with passed parameter 
-            if (!$newtext){
+            if (stripos($text, '{alert ') !== false) {
                 $newtext = preg_replace_callback('/\{alert\s(.*?)\}(.*?)\{\/alert\}/is',
                 function($matches) {
                     return '<div class="alert alert-' . $matches[1] . '" role="alert"><p>' . $matches[2] . '</p></div>';
                 }, $text);
             }
+            if (!$newtext){
+                // If alert <style> parameter is not included, default to alert-warning
+                $newtext = preg_replace_callback('/\{alert}(.*?)\{\/alert\}/is',
+                    function($matches) {
+                        return '<div class="alert alert-warning" role="alert"><p>' . $matches[1] . '</p></div>';
+                    }, $text);
+            }
+
             if ($newtext !== false) {
                 $text = $newtext;
                 $changed = true;


### PR DESCRIPTION
Updated `{alert`} to allow for contextual class stying, Eg, `{alert primary}` or `{alert success}`. You can view a list of the contextual classes [here](https://getbootstrap.com/docs/4.0/components/alerts/)
![Example showing the alerts with styling](https://i.imgur.com/QEwwPrN.png)