### PR TITLE
Added new {ifincohort idname|idnumber}{/ifincohort} tags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [2.0.1] 2020-10-02
+## [2.0.1] dev-2020-10-04
 ### Added
 - New {alert}{/alert} tags (ALPHA).
+- New {ifincohort idname|idnumber}{/ifincohort} tags.
 
 ## [2.0.0] 2020-07-01
 ### Added

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Note: {if`rolename`} and {ifmin`rolename`} type tags are based on role archetype
 * {ifinsection}{/ifinsection} : Will display the enclosed content only if the user is in a section of a course which is not the Front Page.
 * {ifnotinsection}{/ifnotinsection} : Will display the enclosed content only if the user is not in a section of a course.
 * {ifcourserequests}{/ifcourserequests} : Will display enclosed contents only if the Request a Course feature is enabled.
+* {ifincohort idname|idnumber}{/ifincohort} : Will display enclosed content only if user is a member of the specified cohort. You can specify the ID of the cohort or the ID Number field in your cohort settings.
 
 If the condition is not met in the particular context, the specified tag and it's content will be removed.
 
@@ -585,6 +586,7 @@ Create a Page on your Moodle site and include the following code:
 * If in a course [{ifincourse}]Yes[{/ifincourse}]? {ifincourse}Yes{/ifincourse}
 * If in a section of a course [{ifinsection}]Yes[{/ifinsection}][{ifnotinsection}]No[{/ifnotinsection}]? {ifinsection}Yes{/ifinsection}{ifnotinsection}No{/ifnotinsection}
 * If Request a course is enabled [{ifcourserequests}]Yes[{/ifcourserequests}]? {ifcourserequests}Yes{/ifcourserequests}
+* Are you a member of the "moodlers" cohort [{ifincohort moodlers}]Yes[{/ifincohort}]? {ifincohort moodlers}Yes{/ifincohort}
 
 You can switch to different roles to see how each will affect the content being displayed.
 

--- a/filter.php
+++ b/filter.php
@@ -1427,6 +1427,29 @@ class filter_filtercodes extends moodle_text_filter {
                 }
             }
 
+            // Tag: {ifincohort idname|idnumber}.
+            if (stripos($text, '{ifincohort ') !== false) {
+                static $mycohorts;
+                if (empty($mycohorts)) { // Cache list of cohorts.
+                    require_once($CFG->dirroot.'/cohort/lib.php');
+                    $mycohorts = cohort_get_user_cohorts($USER->id);
+                }
+                $newtext = preg_replace_callback('/\{ifincohort (\w*)\}(.*?)\{\/ifincohort\}/is',
+                    function ($matches) use($mycohorts) {
+                        foreach ($mycohorts as $cohort) {
+                            if ($cohort->idnumber == $matches[1] || $cohort->id == $matches[1]) {
+                                return ($matches[2]);
+                            };
+                        }
+                        return '';
+                    }, $text
+                );
+                if ($newtext !== false) {
+                    $text = $newtext;
+                    $changed = true;
+                }
+            }
+
             // Tag: {ifeditmode}.
             if (stripos($text, '{ifeditmode}') !== false) {
                 // If editing mode is activated...


### PR DESCRIPTION
New feature as requested in #74 . The required parameter can either be the ID of the cohort or the idnumber field as defined in the cohort's settings.