### PR TITLE
{courseprogress} tags now show 0 progress.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 - New {alert}{/alert} tags (ALPHA).
 - New {ifincohort idname|idnumber}{/ifincohort} tags.
+### Updated
+- {courseprogress} and {courseprogressbar} now show zero progress if progress is 0.
 
 ## [2.0.0] 2020-07-01
 ### Added

--- a/filter.php
+++ b/filter.php
@@ -828,8 +828,8 @@ class filter_filtercodes extends moodle_text_filter {
                 if ($PAGE->course->enablecompletion == 1
                         && isloggedin()
                         && !isguestuser()
-                        && context_system::instance() != 'page-site-index'
-                        && $comppc = \core_completion\progress::get_course_progress_percentage($PAGE->course)) {
+                        && context_system::instance() != 'page-site-index') {
+                    $comppc = \core_completion\progress::get_course_progress_percentage($PAGE->course);
                     // Course completion progress percentage.
                     $comppercent = number_format($comppc, 0);
                     if (stripos($text, '{courseprogress}') !== false) {


### PR DESCRIPTION
This fixes issue reported in ticket #127 