### PR TITLE
Add new settings to restrict diskfreespace, diskfreespacedata, ipaddress, sesskey tags

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -526,14 +526,16 @@ class filter_filtercodes extends moodle_text_filter {
             }
         }
 
-        // Tag: {diskfreespace} - free space of Moodle application volume.
-        if (stripos($text, '{diskfreespace}') !== false) {
-            $replace['/\{diskfreespace\}/i'] = display_size(disk_free_space('.'));
-        }
+        if (get_config('filter_filtercodes', 'enable_diskspace')) { // Must be enabled in FilterCodes settings.
+            // Tag: {diskfreespace} - free space of Moodle application volume.
+            if (stripos($text, '{diskfreespace}') !== false) {
+                $replace['/\{diskfreespace\}/i'] = display_size(disk_free_space('.'));
+            }
 
-        // Tag: {diskfreespacedata} - free space of Moodledata volume.
-        if (stripos($text, '{diskfreespacedata}') !== false) {
-            $replace['/\{diskfreespacedata\}/i'] = display_size(disk_free_space($CFG->dataroot));
+            // Tag: {diskfreespacedata} - free space of Moodledata volume.
+            if (stripos($text, '{diskfreespacedata}') !== false) {
+                $replace['/\{diskfreespacedata\}/i'] = display_size(disk_free_space($CFG->dataroot));
+            }
         }
 
         // Any {user*} tags.
@@ -1271,19 +1273,23 @@ class filter_filtercodes extends moodle_text_filter {
             $replace['/\{protocol\}/i'] = 'http' . ($this->ishttps() ? 's' : '');
         }
 
-        // Tag: {ipaddress}.
-        if (stripos($text, '{ipaddress}') !== false) {
-            $replace['/\{ipaddress\}/i'] = getremoteaddr();
+        if (get_config('filter_filtercodes', 'enable_ipaddress')) { // Must be enabled in FilterCodes settings.
+            // Tag: {ipaddress}.
+            if (stripos($text, '{ipaddress}') !== false) {
+                $replace['/\{ipaddress\}/i'] = getremoteaddr();
+            }
         }
 
-        // Any {sesskey} or %7Bsesskey%7D tags.
-        // Tag: {sesskey}.
-        if (stripos($text, '{sesskey}') !== false) {
-            $replace['/\{sesskey\}/i'] = sesskey();
-        }
-        // Alternative Tag: %7Bsesskey%7D (for encoded URLs).
-        if (stripos($text, '%7Bsesskey%7D') !== false) {
-            $replace['/%7Bsesskey%7D/i'] = sesskey();
+        if (get_config('filter_filtercodes', 'enable_sesskey')) { // Must be enabled in FilterCodes settings.
+            // Any {sesskey} or %7Bsesskey%7D tags.
+            // Tag: {sesskey}.
+            if (stripos($text, '{sesskey}') !== false) {
+                $replace['/\{sesskey\}/i'] = sesskey();
+            }
+            // Alternative Tag: %7Bsesskey%7D (for encoded URLs).
+            if (stripos($text, '%7Bsesskey%7D') !== false) {
+                $replace['/%7Bsesskey%7D/i'] = sesskey();
+            }
         }
 
         // Tag: {sectionid}.

--- a/lang/en/filter_filtercodes.php
+++ b/lang/en/filter_filtercodes.php
@@ -41,6 +41,12 @@ $string['enable_scrape'] = 'Scrape tag support';
 $string['enable_scrape_description'] = 'Enable the scrape tag.';
 $string['escapebraces'] = 'Escape tags';
 $string['escapebraces_desc'] = 'When this option is checked, you will be able to display FilterCode tags without them being interpreted by this filter by wrapping your tag in [ brackets ]. This can be very useful when creating FilterCodes documentation for the teachers and course creators on your Moodle site.<br><br>Example: [{fullname}] will not display the user\'s full name but display the {fullname} tag instead without the brackets.';
+$string['enable_diskspace'] = 'Free disk space tag support';
+$string['enable_diskspace_description'] = 'Enable the diskfreespace and diskfreespacedata tags.';
+$string['enable_ipaddress'] = 'IP address tag support';
+$string['enable_ipaddress_description'] = 'Enable the ipaddress tag.';
+$string['enable_sesskey'] = 'Session key tag support';
+$string['enable_sesskey_description'] = 'Enable the sesskey tag.';
 
 $string['formquickquestion'] = '
 <form action="{wwwroot}/local/contact/index.php" method="post" class="cf contact-us">

--- a/settings.php
+++ b/settings.php
@@ -59,5 +59,29 @@ if ($hassiteconfig) {
         $description = get_string('enable_scrape_description', 'filter_filtercodes');
         $setting = new admin_setting_configcheckbox($name, $title, $description, $default);
         $settings->add($setting);
+
+        // Option to disable disk space filtercodes.
+        $default = 1;
+        $name = 'filter_filtercodes/enable_diskspace';
+        $title = get_string('enable_diskspace', 'filter_filtercodes');
+        $description = get_string('enable_diskspace_description', 'filter_filtercodes');
+        $setting = new admin_setting_configcheckbox($name, $title, $description, $default);
+        $settings->add($setting);
+
+        // Option to disable IP address filtercode.
+        $default = 1;
+        $name = 'filter_filtercodes/enable_ipaddress';
+        $title = get_string('enable_ipaddress', 'filter_filtercodes');
+        $description = get_string('enable_ipaddress_description', 'filter_filtercodes');
+        $setting = new admin_setting_configcheckbox($name, $title, $description, $default);
+        $settings->add($setting);
+
+        // Option to disable session key filtercode.
+        $default = 1;
+        $name = 'filter_filtercodes/enable_sesskey';
+        $title = get_string('enable_sesskey', 'filter_filtercodes');
+        $description = get_string('enable_sesskey_description', 'filter_filtercodes');
+        $setting = new admin_setting_configcheckbox($name, $title, $description, $default);
+        $settings->add($setting);
     }
 }


### PR DESCRIPTION
As a Moodle Partner, there are some tags we do not want our customers having access to.

This patch adds config settings to enable/disable diskfreespace, diskfreespacedata, ipaddress and sesskey tags.

plugin version has not been bumped, and should be done after merging this PR.