### PR TITLE
Fix-182: Replaced Learn Moodle with Moodle Academy in menudev.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - New {coursecardsbyenrol} tag.
 - New {userscountrycount} tag.
 ### Updated
+- Replaced Learn Moodle link with Moodle Academy in menudev.
 - Page Builder link now works in menudev.
 - Photo Editor link now works in menudev.
 - Screen Recorder link now works in menudev.

--- a/filter.php
+++ b/filter.php
@@ -518,7 +518,7 @@ class filter_filtercodes extends moodle_text_filter {
             $menu .= '-###' . PHP_EOL;
             $menu .= '-DevTuts|https://www.youtube.com/watch?v=UY_pcs4HdDM|{getstring}english{/getstring}' . PHP_EOL;
             $menu .= '-Moodle Development School|https://moodledev.moodle.school/|{getstring}english{/getstring}' . PHP_EOL;
-            $menu .= '-Learn Moodle|https://learn.moodle.org/|{getstring}english{/getstring}' . PHP_EOL;
+            $menu .= '-Moodle Academy|https://moodle.academy/|{getstring}english{/getstring}' . PHP_EOL;
             $replace['/\{menudev\}/i'] = $menu;
         }
 


### PR DESCRIPTION
This addresses the request in #182 .