### PR TITLE
Remove capitalisation of langstring component name

### DIFF
--- a/settings/general.php
+++ b/settings/general.php
@@ -134,8 +134,8 @@ $title = get_string('teamcardsformat', 'filter_filtercodes');
 $description = get_string('teamcardsformat_desc', 'filter_filtercodes');
 $choices = ['' => get_string('none'),
         'infoicon' => get_string('icon'),
-        'brief' => get_string('brief', 'filter_filterCodes'),
-        'verbose' => get_string('verbose', 'filter_filterCodes')];
+        'brief' => get_string('brief', 'filter_filtecodes'),
+        'verbose' => get_string('verbose', 'filter_filtercodes')];
 $setting = new admin_setting_configselect($name, $title, $description, $default, $choices);
 $settings->add($setting);
 

--- a/settings/general.php
+++ b/settings/general.php
@@ -134,7 +134,7 @@ $title = get_string('teamcardsformat', 'filter_filtercodes');
 $description = get_string('teamcardsformat_desc', 'filter_filtercodes');
 $choices = ['' => get_string('none'),
         'infoicon' => get_string('icon'),
-        'brief' => get_string('brief', 'filter_filtecodes'),
+        'brief' => get_string('brief', 'filter_filtercodes'),
         'verbose' => get_string('verbose', 'filter_filtercodes')];
 $setting = new admin_setting_configselect($name, $title, $description, $default, $choices);
 $settings->add($setting);


### PR DESCRIPTION
Fixes some missing language string errors as the capitalisation causes Moodle to look in a different lang string file.
```
Invalid get_string() identifier: 'brief' or component 'filter_filterCodes'. Perhaps you are missing $string['brief'] = ''; in /lang/en/filter_filterCodes.php?

    line 353 of /lib/classes/string_manager_standard.php: call to debugging()
    line 7405 of /lib/moodlelib.php: call to core_string_manager_standard->get_string()
    line 137 of /filter/filtercodes/settings/general.php: call to get_string()
    line 32 of /filter/filtercodes/settings.php: call to require()
    line 88 of /lib/classes/plugininfo/filter.php: call to include()
    line 209 of /admin/settings/plugins.php: call to core\plugininfo\filter->load_settings()
    line 8672 of /lib/adminlib.php: call to require()
    line 8800 of /lib/adminlib.php: call to admin_get_root()
    line 26 of /admin/upgradesettings.php: call to admin_write_settings()

Invalid get_string() identifier: 'verbose' or component 'filter_filterCodes'. Perhaps you are missing $string['verbose'] = ''; in /lang/en/filter_filterCodes.php?

    line 353 of /lib/classes/string_manager_standard.php: call to debugging()
    line 7405 of /lib/moodlelib.php: call to core_string_manager_standard->get_string()
    line 138 of /filter/filtercodes/settings/general.php: call to get_string()
    line 32 of /filter/filtercodes/settings.php: call to require()
    line 88 of /lib/classes/plugininfo/filter.php: call to include()
    line 209 of /admin/settings/plugins.php: call to core\plugininfo\filter->load_settings()
    line 8672 of /lib/adminlib.php: call to require()
    line 8800 of /lib/adminlib.php: call to admin_get_root()
    line 26 of /admin/upgradesettings.php: call to admin_write_settings()
```