### PR TITLE
Add CSS class support for details tag

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -2555,6 +2555,7 @@ class filter_filtercodes extends moodle_text_filter {
         }
 
         // Tag: {details}{/details}.
+        // Tag: {details style1}{/details}.
         // Tag: {summary}{/summary}.
         if (stripos($text, '{/details}') !== false) {
             $replace['/\{details\}/i'] = '<details>';
@@ -2562,6 +2563,11 @@ class filter_filtercodes extends moodle_text_filter {
             $replace['/\{\/details\}/i'] = '</details>';
             $replace['/\{summary\}/i'] = '<summary>';
             $replace['/\{\/summary\}/i'] = '</summary>';
+            if (preg_match_all('/\{details ([a-zA-Z0-9-_ ]+)\}/', $text, $matches) !== 0) {
+                foreach ($matches[1] as $cssclass) {
+                    $replace['/\{details ' . $cssclass . '\}/i'] = '<details class="' . $cssclass . '">';
+                }
+            }
         }
 
         // Conditional block tags.


### PR DESCRIPTION
Resolves #230

The regex selector is `[a-zA-Z0-9-_ ]`, which are the only valid css class name characters outside of ISO 10646 U+00A0 and higher.
I've also allowed space so you could add multiple classes to one details tag, e.g.
`{details style1 style2}` would transform to `<details class="style1 style2">`