### PR TITLE
Issue #335: Refactor text_filter to construct archetypes only once.

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025042700;            // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025042900;            // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2014051200;            // Requires Moodle version 2.7 or later.
 $plugin->component = 'filter_filtercodes';  // Full name of the plugin (used for diagnostics).
-$plugin->release   = '2.6.3';
+$plugin->release   = '2.6.4';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
Resolves #335 

- Rename archetypes to archetyperoles, to avoid possible conflict with archtypes in text_filter::hasarchetype().
- Make it static
- Make it private, as it is not accessed from anywhere else.
- Construct it if it has not yet been constructed.
- Change all references to it in the class.
- Bump version

- [x] Passed code standards check
- [x] Passed phpdoc check
- [x] Passed unit tests.
- [x] Version bumped

For quick analysis for a simple page with a single item, time spent in test_filter::__construct() went from roughly 6,000 microseconds to 1,700 microseconds. A saving of about 72%. Bigger savings are expected on more complex pages.