### PR TITLE
Fix Nested If Tags

### DIFF
--- a/classes/text_filter.php
+++ b/classes/text_filter.php
@@ -5001,8 +5001,8 @@ class text_filter extends \filtercodes_base_text_filter {
             // Tag: {iftenant idnumber|tenantid}...{/iftenant}.
             // Description: Display content only if the user is part of the specified tenant on Moodle Workplace.
             // Required Parameter: tenant idnumber or tenantid.
-            // Requires content between tags. TODO move to $this->if_tag.
-            if (stripos($text, '{iftenant') !== false) {
+            // Requires content between tags.
+            if (stripos($text, '{iftenant') !== false && stripos($text, '{/iftenant}') !== false) {
                 if (class_exists('tool_tenant\tenancy')) {
                     // Moodle Workplace.
                     $tenants = \tool_tenant\tenancy::get_tenants();
@@ -5023,20 +5023,15 @@ class text_filter extends \filtercodes_base_text_filter {
                         $currenttenantidnumber = $tenant->idnumber ? $tenant->idnumber : $tenant->id;
                     }
                 }
-                $re = '/{iftenant\s+(.*)\}(.*)\{\/iftenant\}/isuU';
-                $found = preg_match_all($re, $text, $matches);
-                if ($found > 0) {
-                    foreach ($matches[1] as $tenantid) {
-                        $key = '/{iftenant\s+' . $tenantid . '\}(.*)\{\/iftenant\}/isuU';
-                        if ($tenantid == $currenttenantidnumber) {
-                            // Just remove the tags.
-                            $replace[$key] = '$1';
-                        } else {
-                            // Remove the iftenant strings.
-                            $replace[$key] = '';
-                        }
+
+                $this->if_tag(
+                    $text,
+                    $replace,
+                    "iftenant",
+                    function ($tenantid) use ($currenttenantidnumber) {
+                        return $tenantid == $currenttenantidnumber;
                     }
-                }
+                );
             }
 
             // Tag: {ifworkplace}...{/ifworkplace}.

--- a/classes/text_filter.php
+++ b/classes/text_filter.php
@@ -1615,7 +1615,7 @@ class text_filter extends \filtercodes_base_text_filter {
      * @param string $text The text to check fo tags in
      * @param array $replace The array of replacement rules to add to
      * @param string $tagname The tagname to search for
-     * @param callable(string): bool $callableistrue A callable that returns true if the content is to be shown
+     * @param callable $callableistrue Callable taking the arguments, returning true if the content is to be shown
      * @return void Nothing
      */
     private function if_tag(
@@ -1627,7 +1627,7 @@ class text_filter extends \filtercodes_base_text_filter {
         $emit = function (array $stack) use (&$replace, $tagname) {
             $key = '';
             $value = '';
-            for($i = 0; $i < count($stack); $i++) {
+            for ($i = 0; $i < count($stack); $i++) {
                 [$isopening, $args, $istrue] = $stack[$i];
                 if ($isopening) {
                     $key .= '{' . $tagname . '\s+' . $args . '}(.*)';
@@ -1665,12 +1665,12 @@ class text_filter extends \filtercodes_base_text_filter {
 
                     $stack[] = [
                         $isopening,
-                        $match[1], // args
+                        $match[1],
                         end($istrue),
                     ];
 
                     if (!$isopening) {
-                        // Pop the last element
+                        // Pop the last element.
                         array_pop($istrue);
                     }
 

--- a/classes/text_filter.php
+++ b/classes/text_filter.php
@@ -1610,6 +1610,8 @@ class text_filter extends \filtercodes_base_text_filter {
     }
 
     /**
+     * Helper function for creating if tags.
+     *
      * @param string $text The text to check fo tags in
      * @param array $replace The array of replacement rules to add to
      * @param string $tagname The tagname to search for

--- a/classes/text_filter.php
+++ b/classes/text_filter.php
@@ -1615,7 +1615,9 @@ class text_filter extends \filtercodes_base_text_filter {
      * @param string $text The text to check fo tags in
      * @param array $replace The array of replacement rules to add to
      * @param string $tagname The tagname to search for
-     * @param callable $callableistrue Callable taking the arguments, returning 1 if the content is to be shown, 0 for not show, -1 to ignore.
+     * @param callable $callableistrue Callable taking the arguments,
+     *                                 returning 1 if the content is to be shown,
+     *                                 0 for not show, -1 to ignore.
      * @return void Nothing
      */
     private function if_tag(
@@ -4409,7 +4411,7 @@ class text_filter extends \filtercodes_base_text_filter {
             // Tag: {ifincohort idname|idnumber}...{/ifincohort}.
             // Description: Will display content if the user is part of the specified cohort.
             // Parameters: id name or id number of the cohort.
-            // Requires content between tags. TODO new if
+            // Requires content between tags.
             if (stripos($text, '{ifincohort ') !== false) {
                 if (empty($mycohorts)) { // Cache list of cohorts.
                     require_once($CFG->dirroot . '/cohort/lib.php');
@@ -4435,7 +4437,7 @@ class text_filter extends \filtercodes_base_text_filter {
             // Tag: {ifnotincohort idname|idnumber}...{/ifnotincohort}.
             // Description: Will display content if the user is not part of the specified cohort.
             // Parameters: id name or id number of the cohort.
-            // Requires content between tags. TODO new if
+            // Requires content between tags.
             if (stripos($text, '{ifnotincohort ') !== false) {
                 if (empty($mycohorts)) { // Cache list of cohorts.
                     require_once($CFG->dirroot . '/cohort/lib.php');
@@ -4999,7 +5001,7 @@ class text_filter extends \filtercodes_base_text_filter {
             // Tag: {iftenant idnumber|tenantid}...{/iftenant}.
             // Description: Display content only if the user is part of the specified tenant on Moodle Workplace.
             // Required Parameter: tenant idnumber or tenantid.
-            // Requires content between tags. TODO new function
+            // Requires content between tags. TODO move to $this->if_tag.
             if (stripos($text, '{iftenant') !== false) {
                 if (class_exists('tool_tenant\tenancy')) {
                     // Moodle Workplace.
@@ -5055,7 +5057,7 @@ class text_filter extends \filtercodes_base_text_filter {
             // Tag: {ifcustomrole shortrolename}...{/ifcustomrole}.
             // Description: Display content only if user has the role specified by shortrolename in the current context.
             // Parameters: Short role name.
-            // Requires content between tags. TODO new function
+            // Requires content between tags. TODO move to $this->if_tag.
             if (stripos($text, '{ifcustomrole') !== false) {
                 $re = '/{ifcustomrole\s+(.*)\}(.*)\{\/ifcustomrole\}/isuU';
                 $found = preg_match_all($re, $text, $matches);
@@ -5097,7 +5099,7 @@ class text_filter extends \filtercodes_base_text_filter {
             // Tag: {ifnotcustomrole shortrolename}...{/ifnotcustomrole}.
             // Description: Display content only if user does NOT have the role specified by shortrolename in the current context.
             // Required Parameters: Short role name.
-            // Requires content between tags. TODO new function
+            // Requires content between tags. TODO move to $this->if_tag.
             if (stripos($text, '{ifnotcustomrole') !== false) {
                 $re = '/{ifnotcustomrole\s+(.*)\}(.*)\{\/ifnotcustomrole\}/isuU';
                 $found = preg_match_all($re, $text, $matches);
@@ -5139,7 +5141,7 @@ class text_filter extends \filtercodes_base_text_filter {
             // Tag: {ifhasarolename roleshortname}...{/ifhasarolename}.
             // Description: Display content only if user has the role specified by shortrolename ANYWHERE on the site.
             // Parameters: Short role name.
-            // Requires content between tags. TODO new function
+            // Requires content between tags. TODO move to $this->if_tag.
             if (stripos($text, '{ifhasarolename') !== false) {
                 $re = '/{ifhasarolename\s+(.*)\}(.*)\{\/ifhasarolename\}/isuU';
                 $found = preg_match_all($re, $text, $matches);

--- a/classes/text_filter.php
+++ b/classes/text_filter.php
@@ -1610,10 +1610,10 @@ class text_filter extends \filtercodes_base_text_filter {
     }
 
     /**
-     * @param string $text
-     * @param array $replace
-     * @param string $tagname
-     * @param callable(string): bool $callableistrue
+     * @param string $text The text to check fo tags in
+     * @param array $replace The array of replacement rules to add to
+     * @param string $tagname The tagname to search for
+     * @param callable(string): bool $callableistrue A callable that returns true if the content is to be shown
      * @return void
      */
     private function if_tag(

--- a/classes/text_filter.php
+++ b/classes/text_filter.php
@@ -1614,14 +1614,14 @@ class text_filter extends \filtercodes_base_text_filter {
      * @param array $replace The array of replacement rules to add to
      * @param string $tagname The tagname to search for
      * @param callable(string): bool $callableistrue A callable that returns true if the content is to be shown
-     * @return void
+     * @return void Nothing
      */
     private function if_tag(
         string   $text,
         array    &$replace,
         string   $tagname,
         callable $callableistrue,
-    ) {
+    ): void {
         $emit = function (array $stack) use (&$replace, $tagname) {
             $key = '';
             $value = '';

--- a/classes/text_filter.php
+++ b/classes/text_filter.php
@@ -1691,6 +1691,12 @@ class text_filter extends \filtercodes_base_text_filter {
                         }
                         $newstack[] = $item;
                     }
+                    // Fix istrue values for the new stack by assigning the value of the opening tags
+                    // to the closing tags in the final stack.
+                    for ($i = 0; $i < count($newstack) / 2; $i++) {
+                        $newstack[$i][2] = $newstack[count($newstack) - 1 - $i][2];
+                    }
+
                     if (!empty($newstack)) {
                         $emit(array_reverse($newstack));
                     }
@@ -1719,6 +1725,15 @@ class text_filter extends \filtercodes_base_text_filter {
         static $mygroupslist;
         static $mygroupingslist;
         static $mycohorts;
+
+        if ($options['no-cache'] ?? false) {
+            // Reset the static variables if cache is disabled.
+            $profilefields = null;
+            $profiledata = null;
+            $mygroupslist = null;
+            $mygroupingslist = null;
+            $mycohorts = null;
+        }
 
         $replace = []; // Array of key/value filterobjects.
 

--- a/tests/filter_test.php
+++ b/tests/filter_test.php
@@ -308,6 +308,10 @@ final class filter_test extends \advanced_testcase {
                 'before' => '{ifingrouping a}{ifingrouping b}Hello World{/ifingrouping}{/ifingrouping}',
                 'after'  => '',
             ],
+            [
+                'before' => '{ifnotingrouping a}{ifnotingrouping b}Hello World{/ifnotingrouping}',
+                'after'  => '{ifnotingrouping b}Hello World',
+            ],
         ];
 
         foreach ($tests as $test) {

--- a/tests/filter_test.php
+++ b/tests/filter_test.php
@@ -292,6 +292,22 @@ final class filter_test extends \advanced_testcase {
                 'before' => '{glyphicon glyphicon-name}',
                 'after'  => '<span class="glyphicon glyphicon-name" aria-hidden="true"></span>',
             ],
+            [
+                'before' => '{ifingrouping a}{ifingroup b}Hello World{/ifingroup}{/ifingrouping}',
+                'after'  => '',
+            ],
+            [
+                'before' => '{ifingroup b}{ifingrouping a}{ifingroup b}Hello World{/ifingroup}{/ifingrouping}{/ifingroup}',
+                'after'  => '',
+            ],
+            [
+                'before' => '{ifingroup a}{ifingroup b}Hello World{/ifingroup}{/ifingroup}',
+                'after'  => '',
+            ],
+            [
+                'before' => '{ifingrouping a}{ifingrouping b}Hello World{/ifingrouping}{/ifingrouping}',
+                'after'  => '',
+            ],
         ];
 
         foreach ($tests as $test) {

--- a/tests/filter_test.php
+++ b/tests/filter_test.php
@@ -37,6 +37,9 @@ namespace filter_filtercodes;
  * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class filter_test extends \advanced_testcase {
+    /**
+     * @var text_filter $filter The filter to test.
+     */
     private \filter_filtercodes\text_filter $filter;
 
     /**
@@ -150,7 +153,6 @@ final class filter_test extends \advanced_testcase {
             '{ifingroup ' . $group->id . '}Hello{/ifingroup} {ifingroup none}World{/ifingroup}.',
             'Hello .',
         );
-
 
         // Test partials.
         $this->assert_filter_eq(

--- a/tests/filter_test.php
+++ b/tests/filter_test.php
@@ -26,7 +26,6 @@
 
 namespace filter_filtercodes;
 
-use filter_filtercodes;
 
 /**
  * Unit tests for FilterCodes filter.
@@ -38,6 +37,8 @@ use filter_filtercodes;
  * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class filter_test extends \advanced_testcase {
+    private \filter_filtercodes\text_filter $filter;
+
     /**
      * Setup the test framework
      *
@@ -54,6 +55,235 @@ final class filter_test extends \advanced_testcase {
         filter_set_global_state('filtercodes', TEXTFILTER_ON);
 
         $PAGE->set_url(new \moodle_url('/'));
+        $this->filter = new \filter_filtercodes\text_filter();
+    }
+
+    /**
+     * Assert that the filter produces the expected output.
+     *
+     * @param string $before The text before filtering.
+     * @param string $after The expected text after filtering.
+     *
+     * @return void
+     */
+    private function assert_filter_eq(
+        string $before,
+        string $after,
+    ): void {
+        $filtered = $this->filter->filter($before, ['no-cache' => true]);
+        $this->assertEquals($after, $filtered);
+    }
+
+    /**
+     * Test the ifingroup tag.
+     *
+     * @covers \filter_filtercodes\text_filter::filter
+     *
+     * @return void
+     */
+    public function test_filtercode_ifingroup(): void {
+        global $PAGE, $USER;
+
+        $course = $this->getDataGenerator()->create_course();
+        $context = \context_course::instance($course->id);
+
+        // Test the ifingroup tag with a grouping that does not exist.
+        $this->assert_filter_eq(
+            '{ifingroup none}Hello World{/ifingroup}',
+            ''
+        );
+
+        // Set up a group.
+        $group = $this->getDataGenerator()->create_group([
+            'courseid' => $PAGE->course->id,
+            'idnumber' => 'testgroup',
+            'name' => 'Test Group',
+        ]);
+
+        // Test the ifingroup tag with a group not assigned to the user.
+        $this->assert_filter_eq(
+            '{ifingroup ' . $group->id . '}Hello World{/ifingroup}',
+            '',
+        );
+
+        $this->getDataGenerator()->create_group_member([
+            'groupid' => $group->id,
+            'userid' => $USER->id,
+        ]);
+
+        // Test the ifingroup tag with a group assigned to the user.
+        $this->assert_filter_eq(
+            'Finally {ifingroup ' . $group->id . '}Hello World{/ifingroup}',
+            'Finally Hello World',
+        );
+        $this->assert_filter_eq(
+            'Finally with idnumber {ifingroup ' . $group->idnumber . '}Hello World{/ifingroup}',
+            'Finally with idnumber Hello World',
+        );
+
+        // True in true.
+        $this->assert_filter_eq(
+            '{ifingroup ' . $group->id . '}Hello {ifingroup ' . $group->id . '}World{/ifingroup}.{/ifingroup}',
+            'Hello World.',
+        );
+
+        // False in true.
+        $this->assert_filter_eq(
+            '{ifingroup ' . $group->id . '}Hello {ifingroup none}World{/ifingroup}.{/ifingroup}',
+            'Hello .',
+        );
+
+        // True in false.
+        $this->assert_filter_eq(
+            '{ifingroup none}Hello {ifingroup ' . $group->id . '}World{/ifingroup}.{/ifingroup}',
+            '',
+        );
+
+        // False in false.
+        $this->assert_filter_eq(
+            '{ifingroup none}Hello {ifingroup none}World{/ifingroup}.{/ifingroup}',
+            '',
+        );
+
+        // Side by side with ifingrouping.
+        $this->assert_filter_eq(
+            '{ifingroup ' . $group->id . '}Hello{/ifingroup} {ifingroup none}World{/ifingroup}.',
+            'Hello .',
+        );
+
+
+        // Test partials.
+        $this->assert_filter_eq(
+            '{ifingroup ' . $group->id . '}Hello {ifingroup none}World{/ifingroup}.',
+            'Hello {ifingroup none}World.',
+        );
+        $this->assert_filter_eq(
+            '{ifingroup none}Hello World{/ifingroup}{/ifingroup}.',
+            '{/ifingroup}.',
+        );
+        $this->assert_filter_eq(
+            '{ifingroup none}Hello {ifingroup ' . $group->id . '}World{/ifingroup}.',
+            '.',
+        );
+        $this->assert_filter_eq(
+            '{ifingroup none}Hello {ifingroup none}World{/ifingroup}.',
+            '.',
+        );
+        $this->assert_filter_eq(
+            '{ifingroup ' . $group->id . '}Hello {ifingroup none}{ifingroup none}World{/ifingroup}.',
+            'Hello {ifingroup none}{ifingroup none}World.',
+        );
+    }
+
+    /**
+     * Test the ifingrouping tag.
+     *
+     * @covers \filter_filtercodes\text_filter::filter
+     *
+     * @return void
+     */
+    public function test_ifingrouping(): void {
+        global $PAGE, $USER;
+
+        $course = $this->getDataGenerator()->create_course();
+        $context = \context_course::instance($course->id);
+
+        // Test the ifingrouping tag with a grouping that does not exist.
+        $this->assert_filter_eq(
+            '{ifingrouping none}Hello World{/ifingrouping}',
+            ''
+        );
+
+        // Set up a grouping.
+        $grouping = $this->getDataGenerator()->create_grouping([
+            'courseid' => $PAGE->course->id,
+            'idnumber' => 'testgrouping',
+            'name' => 'Test Grouping',
+        ]);
+        $group = $this->getDataGenerator()->create_group([
+            'courseid' => $PAGE->course->id,
+            'idnumber' => 'testgroup',
+            'name' => 'Test Group',
+        ]);
+        $this->getDataGenerator()->create_grouping_group([
+            'groupingid' => $grouping->id,
+            'groupid' => $group->id,
+        ]);
+
+        // Test the ifingrouping tag with a grouping not assigned to the user.
+        $this->assert_filter_eq(
+            '{ifingrouping ' . $grouping->id . '}Hello World{/ifingrouping}',
+            '',
+        );
+
+        // Assign the user to the group.
+        $this->getDataGenerator()->create_group_member([
+            'groupid' => $group->id,
+            'userid' => $USER->id,
+        ]);
+
+        // Test the ifingrouping tag with a grouping assigned to the user.
+        $this->assert_filter_eq(
+            'Finally {ifingrouping ' . $grouping->id . '}Hello World{/ifingrouping}',
+            'Finally Hello World',
+        );
+
+        $this->assert_filter_eq(
+            'Finally with idnumber {ifingrouping ' . $grouping->idnumber . '}Hello World{/ifingrouping}',
+            'Finally with idnumber Hello World',
+        );
+
+        // True in true.
+        $this->assert_filter_eq(
+            '{ifingrouping ' . $grouping->id . '}Hello {ifingrouping ' . $grouping->id . '}World{/ifingrouping}.{/ifingrouping}',
+            'Hello World.',
+        );
+
+        // False in true.
+        $this->assert_filter_eq(
+            '{ifingrouping ' . $grouping->id . '}Hello {ifingrouping none}World{/ifingrouping}.{/ifingrouping}',
+            'Hello .',
+        );
+
+        // True in false.
+        $this->assert_filter_eq(
+            '{ifingrouping none}Hello {ifingrouping ' . $grouping->id . '}World{/ifingrouping}.{/ifingrouping}',
+            '',
+        );
+
+        // False in false.
+        $this->assert_filter_eq(
+            '{ifingrouping none}Hello {ifingrouping none}World{/ifingrouping}.{/ifingrouping}',
+            '',
+        );
+
+        // Side by side.
+        $this->assert_filter_eq(
+            '{ifingrouping ' . $grouping->id . '}Hello{/ifingrouping} {ifingrouping none}World{/ifingrouping}.',
+            'Hello .',
+        );
+
+        // Test partials.
+        $this->assert_filter_eq(
+            '{ifingrouping ' . $grouping->id . '}Hello {ifingrouping none}World{/ifingrouping}.',
+            'Hello {ifingrouping none}World.',
+        );
+        $this->assert_filter_eq(
+            '{ifingrouping none}Hello World{/ifingrouping}{/ifingrouping}.',
+            '{/ifingrouping}.',
+        );
+        $this->assert_filter_eq(
+            '{ifingrouping none}Hello {ifingrouping ' . $grouping->id . '}World{/ifingrouping}.',
+            '.',
+        );
+        $this->assert_filter_eq(
+            '{ifingrouping none}Hello {ifingrouping none}World{/ifingrouping}.',
+            '.',
+        );
+        $this->assert_filter_eq(
+            '{ifingrouping ' . $grouping->id . '}Hello {ifingrouping none}{ifingrouping none}World{/ifingrouping}.',
+            'Hello {ifingrouping none}{ifingrouping none}World.',
+        );
     }
 
     /**
@@ -65,10 +295,6 @@ final class filter_test extends \advanced_testcase {
      */
     public function test_filtercodes(): void {
         global $CFG, $USER, $DB, $PAGE;
-
-        // Create a test course.
-        $course = $this->getDataGenerator()->create_course();
-        $context = \context_course::instance($course->id);
 
         $tests = [
             [
@@ -293,11 +519,7 @@ final class filter_test extends \advanced_testcase {
                 'after'  => '<span class="glyphicon glyphicon-name" aria-hidden="true"></span>',
             ],
             [
-                'before' => '{ifingrouping a}{ifingroup b}Hello World{/ifingroup}{/ifingrouping}',
-                'after'  => '',
-            ],
-            [
-                'before' => '{ifingroup b}{ifingrouping a}{ifingroup b}Hello World{/ifingroup}{/ifingrouping}{/ifingroup}',
+                'before' => '{ifingrouping a}{ifingrouping b}Hello World{/ifingrouping}{/ifingrouping}',
                 'after'  => '',
             ],
             [
@@ -305,8 +527,12 @@ final class filter_test extends \advanced_testcase {
                 'after'  => '',
             ],
             [
-                'before' => '{ifingrouping a}{ifingrouping b}Hello World{/ifingrouping}{/ifingrouping}',
-                'after'  => '',
+                'before' => '{ifnotingrouping a}{ifnotingrouping b}Hello World{/ifnotingrouping}{/ifnotingrouping}',
+                'after'  => 'Hello World',
+            ],
+            [
+                'before' => '{ifnotingroup a}{ifnotingroup b}Hello World{/ifnotingroup}{/ifnotingroup}',
+                'after'  => 'Hello World',
             ],
             [
                 'before' => '{ifnotingrouping a}{ifnotingrouping b}Hello World{/ifnotingrouping}',

--- a/tests/filter_test.php
+++ b/tests/filter_test.php
@@ -289,6 +289,68 @@ final class filter_test extends \advanced_testcase {
     }
 
     /**
+     * Test the ifprofile tag.
+     *
+     * @covers \filter_filtercodes\text_filter::filter
+     *
+     * @return void
+     */
+    public function test_ifprofile(): void {
+        global $USER;
+
+        // Set up a user with specific profile fields.
+        $USER->city = 'New York';
+        $USER->country = 'US';
+        $USER->email = 'testuser@example.com';
+
+        // Test the 'is' condition.
+        $this->assert_filter_eq(
+            '{ifprofile city is "New York"}Welcome to New York{/ifprofile}',
+            'Welcome to New York'
+        );
+        $this->assert_filter_eq(
+            '{ifprofile city is "Los Angeles"}Welcome to LA{/ifprofile}',
+            ''
+        );
+
+        // Test the 'not' condition.
+        $this->assert_filter_eq(
+            '{ifprofile city not "Los Angeles"}Not in LA{/ifprofile}',
+            'Not in LA'
+        );
+        $this->assert_filter_eq(
+            '{ifprofile city not "New York"}Not in NY{/ifprofile}',
+            ''
+        );
+
+        // Test the 'contains' condition.
+        $this->assert_filter_eq(
+            '{ifprofile email contains "example.com"}Valid email{/ifprofile}',
+            'Valid email'
+        );
+        $this->assert_filter_eq(
+            '{ifprofile email contains "invalid.com"}Invalid email{/ifprofile}',
+            ''
+        );
+
+        // Test the 'in' condition.
+        $this->assert_filter_eq(
+            '{ifprofile country in "US,CA"}North America{/ifprofile}',
+            'North America'
+        );
+        $this->assert_filter_eq(
+            '{ifprofile country in "UK,FR"}Europe{/ifprofile}',
+            ''
+        );
+
+        // Nested conditions.
+        $this->assert_filter_eq(
+            '{ifprofile city is "New York"}{ifprofile country is "US"}Welcome to the US{/ifprofile}{/ifprofile}',
+            'Welcome to the US'
+        );
+    }
+
+    /**
      * Filter test.
      *
      * @covers \filter_filtercodes
@@ -539,6 +601,14 @@ final class filter_test extends \advanced_testcase {
             [
                 'before' => '{ifnotingrouping a}{ifnotingrouping b}Hello World{/ifnotingrouping}',
                 'after'  => '{ifnotingrouping b}Hello World',
+            ],
+            [
+                'before' => '{ifactivitycompleted 123456}Hello World{/ifactivitycompleted}',
+                'after'  => '{ifactivitycompleted 123456}Hello World{/ifactivitycompleted}',
+            ],
+            [
+                'before' => '{ifnotactivitycompleted 123456}Hello World{/ifnotactivitycompleted}',
+                'after'  => '{ifnotactivitycompleted 123456}Hello World{/ifnotactivitycompleted}',
             ],
         ];
 


### PR DESCRIPTION
`{ifingroup a}{ifingroup b}Hello World{/ifingroup}{/ifingroup}` -> `{/ifingroup}`

and so on lead to mismatches and wrong output. In stage one i added some tests for bug reproduction. Only nestings of the same filtercode category are affected.

I propose matching all nestings of groupings generating replacements for all tags at once, e.g.:
1. Check grouping openings -> `{ifingroup a}{ifingroup b}`
2. Generate Matcher: `'/{ifingroup\s+a\}(.*)/{ifingroup\s+b\}(.*)\{\/ifingroup\}(.*)\{\/ifingroup\}/isuU'`
3. Replace either with:
 - 'a = true, b = true' => `'$1$2$3'`
 - 'a = true, b = false' => `'$1$3'`
 - 'a = false, b = true' => `''`
 - 'a = false, b = false' => `''`
 
 I will now implement a proof of concept